### PR TITLE
doc: addSearchExtra can be an object

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -180,7 +180,7 @@ Search.prototype.setLimit = function (limit) {
 /**
  * Add a search extra element (specific to category)
  * @param {String} key   The name of search extra
- * @param {String} value The value of search extra
+ * @param {Object} value The value of search extra
  */
 Search.prototype.addSearchExtra = function (key, value) {
     if (!!key && !!value) {


### PR DESCRIPTION
Small doc change to fix a warning (addSearchExtra value type)