### PR TITLE
Fixes for error handling, and query by main category

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -149,6 +149,7 @@ Search.prototype.setCategory = function (category) {
             var filteredCategory = _(categories)
             .map(cat => cat.subcategories)
             .flatten()
+            .concat(categories)
             .filter(cat => cat.channel === category)
             .value()[0];
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -400,6 +400,10 @@ Search.prototype.run = function (options, bodyParams) {
 
                 });
             });
+            
+            req.on('error', err => {
+                reject(err);
+            });
 
             req.write(JSON.stringify(bodyParams));
             req.end();

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -175,6 +175,34 @@ describe('Search', function() {
         });
     });
 
+    
+    describe('SetCategory', function() {
+
+        it('check when category is a number', function(done) {
+            var s = new search.Search();
+            s.setCategory(5);
+            
+            s.category.should.equal(5);
+            done();
+        });
+
+        it('check when category is a sub category name', function(done) {
+            var s = new search.Search();
+            s.setCategory('electromenager');
+            
+            s.category.should.equal('20');
+            done();
+        });
+
+        it('check when category is a main category name', function(done) {
+            var s = new search.Search();
+            s.setCategory('_maison_');
+            
+            s.category.should.equal('18');
+            done();
+        });
+    });
+
     // describe('Parsers', function() {
     //     it('Parse NbResult', function(done) {
     //         var html = '<header class="tabsHeader clearfix"><nav class="fl"><a href="//www.leboncoin.fr/annonces/offres/ile_de_france//?ur=1" title="Afficher toutes les annonces" class="tabsSwitch trackable active" data-info=\'{"event_name" : "ad_search::ongvar::toutes_les_annonces", "event_type" : "click", "event_s2" : "8", "click_type" : "N"}\'>Toutes<span class="tabsSwitchNumbers small-hidden tiny-hidden"> 21 661</span></a><a href="//www.leboncoin.fr/annonces/offres/ile_de_france//?ur=1&amp;f=p" title="Afficher uniquement les annonces de Particuliers" class="tabsSwitch trackable" data-info=\'{"event_name" : "ad_search::ongvar::particuliers", "event_type" : "click", "event_s2" : "8", "click_type" : "N"}\'>Part<span class="custom-medium-hidden">iculiers</span><span class="tabsSwitchNumbers small-hidden tiny-hidden"> 14 451</span></a><a href="//www.leboncoin.fr/annonces/offres/ile_de_france//?ur=1&amp;f=c" title="Afficher uniquement les annonces de Professionnels" class="tabsSwitch trackable" data-info=\'{"event_name" : "ad_search::ongvar::professionnels", "event_type" : "click", "event_s2" : "8", "click_type" : "N"}\'>Pro<span class="custom-medium-hidden">fessionnels</span><span class="tabsSwitchNumbers small-hidden tiny-hidden"> 7 210</span></a></nav><article class="list_properties"> <a title="Trier les annonces par prix" href="//www.leboncoin.fr/annonces/offres/ile_de_france//?ur=1&amp;sp=1" class="trackable" data-info=\'{"event_name" : "ad_search::trier_par_prix", "event_type" : "click", "event_s2" : "8", "click_type" : "N"}\'><i class="icon-currency-eur"></i>Tri<span class="custom-medium-hidden">er par prix</span></a> </article></header>';


### PR DESCRIPTION
This PR contains two commits : 
  * one to redirect any http connection error to Promise.reject() (in case of connection lost, for example),
  * the other to be able to filter a whole main category instead of only its sub cats.