### PR TITLE
Manage not found item on Item.getDetails

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -60,6 +60,9 @@ Item.prototype.getDetails = function () {
             if(err) {
                 return reject(err);
             }
+            if (!res.body) {
+                return reject(`Item ${self.id} not found`);
+            }
             var entry = JSON.parse(res.body);
 
             var attributes = {};


### PR DESCRIPTION
If I provide an item Id that is not referenced in leboncoin (because of some mistake or if it has been removed), the module throws an error when you parse the body result of your request (`var entry = JSON.parse(res.body)`), since the body is null or undefined.
We could check the `statusCode` (`res.statusCode !== 200`), but I have no clue if leboncoin could send something else.
This PR contains something that manages this, and reject a proper error description.