### PR TITLE
Add fake request headers to bypass API restrictions

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -237,6 +237,9 @@ Search.prototype.getUrlOptions = function () {
             "content-type": "text/plain;charset=UTF-8",
             "accept": "*/*",
             "referer": "https://www.leboncoin.fr/annonces/offres/ile_de_france/",
+            "User-Agent": "leboncoin-api (+https://github.com/tdurieux/leboncoin-api/)",
+            "Accept-Language": "*",
+            "Accept-Encoding": "*",
         }
     }
 }


### PR DESCRIPTION
Just having the headers seems to be enough, the actual values are ignored. See #53 for discussion.

User-Agent format is based on usual bot user-agent syntax `name (+url)` [as used by Google for example](https://support.google.com/webmasters/answer/1061943?hl=en).