### PR TITLE
Use package.json information to set user-agent string

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -237,6 +237,9 @@ Search.prototype.getUrlOptions = function () {
             "content-type": "text/plain;charset=UTF-8",
             "accept": "*/*",
             "referer": "https://www.leboncoin.fr/annonces/offres/ile_de_france/",
+            "User-Agent": "leboncoin-api (+https://github.com/tdurieux/leboncoin-api/)",
+            "Accept-Language": "*",
+            "Accept-Encoding": "*",
         }
     }
 }

--- a/lib/search.js
+++ b/lib/search.js
@@ -3,6 +3,7 @@ const request = require('request');
 const url = require('url');
 const iconv = require('iconv-lite');
 
+const packageJson = require('../package.json');
 const filters = require('./filters');
 const item = require('./item');
 const cleanString = require('./utils').cleanString;
@@ -237,7 +238,7 @@ Search.prototype.getUrlOptions = function () {
             "content-type": "text/plain;charset=UTF-8",
             "accept": "*/*",
             "referer": "https://www.leboncoin.fr/annonces/offres/ile_de_france/",
-            "User-Agent": "leboncoin-api (+https://github.com/tdurieux/leboncoin-api/)",
+            "User-Agent": `${packageJson.name}/${packageJson.version} (+${packageJson.bugs.url})`,
             "Accept-Language": "*",
             "Accept-Encoding": "*",
         }


### PR DESCRIPTION
Warning: requires #56 to be merged.

This PR automates user-agent string with information coming from `package.json`. Be aware that I have absolutely no idea how the following line behaves on environments that are **not** node.js:
```js
const packageJson = require('../package.json');
```
It works completely fine on node.js because `package.json` can be reached from `node_modules`, but if this script is to be used in projects not using `node_modules` or not including `package.json` it will not work.

Do such projects even exist? Should this library cater to them? I'll let you decide because I have very minimal experience with the whole JS/NPM stack and basically don't know what is possible or not.