### PR TITLE
Add Paris timezone to dates when parseData

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -330,6 +330,8 @@ const parseData = function (data) {
             })
         }
 
+        var parisGMT = utils.getParisGMT();
+
         output.push(new item.Item({
             title: entry.subject,
             description: entry.body,
@@ -339,8 +341,8 @@ const parseData = function (data) {
             location: entry.location,
             urgent: entry.urgent ? entry.urgent : false,
             price: entry.price ? entry.price[0] : 0,
-            date: new Date(entry.first_publication_date),
-            date_index: new Date(entry.index_date),
+            date: new Date(entry.first_publication_date + " " + parisGMT),
+            date_index: new Date(entry.index_date + " " + parisGMT),
             owner: entry.owner,
             attributes: attributes
         }));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,4 +9,9 @@ module.exports.requestHeaders = {
     'Content-Type': 'application/json',
     'Referer': "https://www.leboncoin.fr/recherche/",
     'Origin': 'https://www.leboncoin.fr'
-}
+};
+module.exports.getParisGMT = function() {
+    var d = new Date();
+    var s = d.toLocaleString(undefined, { timeZone: "Europe/Paris", timeZoneName: "short" });
+    return s.slice(-5)
+};


### PR DESCRIPTION
Date are not parsed with timezone so the lib is showing wrong dates when using it outside France.
I used [`toLocaleString`](https://stackoverflow.com/questions/35888335/get-timezone-offset-of-another-timezone-in-javascript-without-using-strings) because it could be CET ou CEST. Maybe it could be cleaner to use a timezone lib ([zonedTimeToUtc()](https://date-fns.org/v2.0.0-alpha.27/docs/Time-Zones#synopsis)).
