### PR TITLE
Requests : handle invalid "successful" responses

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -363,8 +363,11 @@ Search.prototype.run = function (options, bodyParams) {
                 json: bodyParams,
                 gzip: true
             }, function optionalCallback(err, httpResponse, jsonResult) {
-                if (err) {
-                    return reject(err);
+                if (err || httpResponse.statusCode>=400) {
+                  return reject(err || `HTTP err : ${httpResponse.statusCode} ${httpResponse.statusMessage}`);
+                }
+                if (!jsonResult || !jsonResult.ads){
+                  return reject('Invalid response - no ads received');
                 }
                 var results = parseData(jsonResult.ads);                        
                 var output = {

--- a/lib/search.js
+++ b/lib/search.js
@@ -364,10 +364,10 @@ Search.prototype.run = function (options, bodyParams) {
                 gzip: true
             }, function optionalCallback(err, httpResponse, jsonResult) {
                 if (err || httpResponse.statusCode>=400) {
-                  return reject(err || `HTTP err : ${httpResponse.statusCode} ${httpResponse.statusMessage}`);
+                  return reject(err || new Error(`HTTP err : ${httpResponse.statusCode} ${httpResponse.statusMessage}`));
                 }
                 if (!jsonResult || !jsonResult.ads){
-                  return reject('Invalid response - no ads received');
+                  return reject(new Error('Invalid response - no ads received'));
                 }
                 var results = parseData(jsonResult.ads);                        
                 var output = {


### PR DESCRIPTION
Fails graciously when 
* HTTP >= 400
* No `ads` in the JSON body

Instead of a TypeError while trying to parse `jsonResult.ads`

(Thanks a lot for the API wrapper!)